### PR TITLE
Use jaxb 2.3.1 or newer to avoid deprecation warnings on Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
-            <version>2.2.7</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>psidev.psi.tools</groupId>


### PR DESCRIPTION
See:
https://github.com/eclipse-ee4j/jaxb-ri/issues/1197
https://github.com/javaee/jaxb-v2/commit/9805bc91473a9f4dee95e7192998a5bbb61350f2
https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/
https://github.com/javaee/jaxb-v2/blob/master/README.md
https://javaee.github.io/jaxb-v2/doc/user-guide/ch03.html#deployment-maven-coordinates